### PR TITLE
change table name from 'assets' to 'holdings'

### DIFF
--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -1,4 +1,4 @@
-class Asset < ApplicationRecord
+class Holding < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :price, presence: true
 end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,5 +1,5 @@
 class Stock < ApplicationRecord
-  belongs_to :asset
+  belongs_to :holding
   belongs_to :wallet
 
   validates :quantity, :initial_price, presence: true

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -1,5 +1,5 @@
 class Wallet < ApplicationRecord
   belongs_to :user
   has_many :stocks, dependent: :destroy
-  has_many :assets, through: :stocks
+  has_many :holdings, through: :stocks
 end

--- a/db/migrate/20240611015330_rename_assets_to_holdings.rb
+++ b/db/migrate/20240611015330_rename_assets_to_holdings.rb
@@ -1,0 +1,5 @@
+class RenameAssetsToHoldings < ActiveRecord::Migration[7.1]
+  def change
+    rename_table :assets, :holdings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_10_184511) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_11_015330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "assets", force: :cascade do |t|
+  create_table "holdings", force: :cascade do |t|
     t.string "name"
     t.float "price"
     t.datetime "created_at", null: false
@@ -54,7 +54,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_184511) do
     t.index ["user_id"], name: "index_wallets_on_user_id"
   end
 
-  add_foreign_key "stocks", "assets"
+  add_foreign_key "stocks", "holdings", column: "asset_id"
   add_foreign_key "stocks", "wallets"
   add_foreign_key "wallets", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 #   end
 
 User.destroy_all
-Asset.destroy_all
+Holding.destroy_all
 Wallet.destroy_all
 Stock.destroy_all
 
@@ -19,10 +19,10 @@ user_2 = User.create(first_name: "Vitalik", last_name: "Buterin", email: "vitali
 puts "user created"
 
 puts "creating assets..."
-asset_1 = Asset.create(name: "Bitcoin", price: 65.75)
-asset_2 = Asset.create(name: "Petrobras", price: 32.50)
-asset_3 = Asset.create(name: "Ethereum", price: 25.60)
-asset_4 = Asset.create(name: "Itau", price: 12.50)
+asset_1 = Holding.create(name: "Bitcoin", price: 65.75)
+asset_2 = Holding.create(name: "Petrobras", price: 32.50)
+asset_3 = Holding.create(name: "Ethereum", price: 25.60)
+asset_4 = Holding.create(name: "Itau", price: 12.50)
 puts "assets created"
 
 puts "creating wallets..."


### PR DESCRIPTION
change table name from 'assets' to 'holdings' to avoid name conflicts with 'assets' directory in styling. 

Bear in mind that in finance 'assets' and 'holdings' mean the same thing. 